### PR TITLE
Proposition des motifs de décision en fonction du type de formulaire

### DIFF
--- a/app/components/views/reports/confirmations/edit_component.rb
+++ b/app/components/views/reports/confirmations/edit_component.rb
@@ -10,12 +10,16 @@ module Views
           super()
         end
 
+        def applicable?
+          @report.applicable? || @report.approved?
+        end
+
         def resolution_motif_choices
-          if @report.applicable? || @report.approved?
-            I18n.t("enum.resolution_motif.applicable").map(&:reverse)
-          else
-            I18n.t("enum.resolution_motif.inapplicable").map(&:reverse)
-          end
+          enum_path = ["enum.resolution_motif"]
+          enum_path << @report.form_type
+          enum_path << (applicable? ? "applicable" : "inapplicable")
+
+          I18n.t(enum_path.join("."), default: {}).map(&:reverse)
         end
       end
     end

--- a/app/components/views/reports/resolutions/edit_component.html.slim
+++ b/app/components/views/reports/resolutions/edit_component.html.slim
@@ -15,9 +15,13 @@
 
       = render Views::Reports::ShortDetailsComponent.new(@report)
 
-      = form.block :resolution_motif do
+      = form.block :resolution_motif do |block|
         = form.label :resolution_motif, "Motif :"
         = form.select :resolution_motif, resolution_motif_choices, resolution_motif_options, autofocus: true
+
+        - if resolution_motif_choices.empty?
+          - block.with_hint do
+            ' Aucun motif de décision n'a encore été validé par l'administration.
 
       = form.block :reponse do |block|
         = form.label :reponse, "Vous pouvez transmettre des observations à la collectivité :"

--- a/app/components/views/reports/resolutions/edit_component.rb
+++ b/app/components/views/reports/resolutions/edit_component.rb
@@ -13,16 +13,22 @@ module Views
           super()
         end
 
+        def applicable?
+          @state == "applicable"
+        end
+
         def resolution_motif_choices
-          if @state == "applicable"
-            I18n.t("enum.resolution_motif.applicable").map(&:reverse)
-          else
-            I18n.t("enum.resolution_motif.inapplicable").map(&:reverse)
-          end
+          enum_path = ["enum.resolution_motif"]
+          enum_path << @report.form_type
+          enum_path << (applicable? ? "applicable" : "inapplicable")
+
+          I18n.t(enum_path.join("."), default: {}).map(&:reverse)
         end
 
         def resolution_motif_options
-          if resolution_motif_choices.size > 1
+          if resolution_motif_choices.empty?
+            { include_blank: "Aucun motif disponible" }
+          elsif resolution_motif_choices.size > 1
             { prompt: "Sélectionnez un motif" }
           else
             {}

--- a/config/locales/enum.fr.yml
+++ b/config/locales/enum.fr.yml
@@ -325,12 +325,46 @@ fr:
       doublon:                        "Signalement en doublon, déjà pris en charge"
       absence_incoherence:            "Aucune incohérence décelée"
 
-      applicable:
-        maj_local:                      "Descriptif du local mis à jour"
-        maj_exoneration:                "Exonérations mises à jour"
-        maj_occupation:                 "Occupation du local mise à jour"
-        application_majoration_ths:     "Application de la majoration THS"
-        doublon:                        "Signalement en doublon, déjà pris en charge"
+      evaluation_local_habitation:
+        applicable:
+          maj_local:                    "Descriptif du local mis à jour"
+          maj_exoneration:              "Exonérations mises à jour"
+          doublon:                      "Signalement en doublon, déjà pris en charge"
+        inapplicable:
+          absence_incoherence:          "Aucune incohérence décelée"
 
-      inapplicable:
-        absence_incoherence: "Aucune incohérence décelée"
+      evaluation_local_professionnel:
+        applicable:
+          maj_local:                    "Descriptif du local mis à jour"
+          maj_exoneration:              "Exonérations mises à jour"
+          doublon:                      "Signalement en doublon, déjà pris en charge"
+        inapplicable:
+          absence_incoherence:          "Aucune incohérence décelée"
+
+      creation_local_habitation:
+        applicable:
+          maj_local:                    "Descriptif du local mis à jour"
+          maj_exoneration:              "Exonérations mises à jour"
+          doublon:                      "Signalement en doublon, déjà pris en charge"
+        inapplicable:
+          absence_incoherence:          "Aucune incohérence décelée"
+
+      creation_local_professionnel:
+        applicable:
+          maj_local:                    "Descriptif du local mis à jour"
+          maj_exoneration:              "Exonérations mises à jour"
+          doublon:                      "Signalement en doublon, déjà pris en charge"
+        inapplicable:
+          absence_incoherence:          "Aucune incohérence décelée"
+
+      occupation_local_habitation:
+        applicable:
+          maj_occupation:               "Occupation du local mise à jour"
+          application_majoration_ths:   "Application de la majoration THS"
+        inapplicable:
+          absence_incoherence:          "Aucune incohérence décelée"
+
+      occupation_local_professionnel:
+        applicable:
+        inapplicable:
+          absence_incoherence:          "Aucune incohérence décelée"

--- a/config/locales/models.fr.yml
+++ b/config/locales/models.fr.yml
@@ -547,3 +547,11 @@ fr:
           attributes:
             office_id:
               blank: Un guichet est requis
+
+        reports/states/resolve_service:
+          attributes:
+            state:
+              inclusion:  "Le statut n'est pas valide"
+            resolution_motif:
+              blank:      "Un motif est requis"
+              inclusion:  "Le motif sélectionné n'est pas valide"

--- a/db/migrate/20241011075049_add_occupation_motifs.rb
+++ b/db/migrate/20241011075049_add_occupation_motifs.rb
@@ -14,6 +14,25 @@ class AddOccupationMotifs < ActiveRecord::Migration[7.2]
       absence_incoherence
     ]
 
+    # Update invalid resolution motifs, when it could be updated
+    execute <<~SQL.squish
+      UPDATE  reports
+      SET     resolution_motif = 'maj_occupation'
+      WHERE   form_type        = 'occupation_local_habitation'
+        AND   resolution_motif = 'maj_local'
+    SQL
+
+    # Reset any other resolved reports with invalid motifs
+    execute <<~SQL.squish
+      UPDATE  reports
+      SET     state = 'assigned', resolution_motif = NULL
+      WHERE   state IN ('applicable', 'approved')
+        AND   (
+                   (form_type = 'occupation_local_habitation' AND resolution_motif IN ('maj_exoneration', 'doublon'))
+                OR (form_type = 'occupation_local_professionnel')
+              )
+    SQL
+
     change_column :reports, :resolution_motif, :enum,
       enum_type: :resolution_motif,
       using:     "resolution_motif::resolution_motif"
@@ -29,6 +48,13 @@ class AddOccupationMotifs < ActiveRecord::Migration[7.2]
       absence_incoherence
       doublon
     ]
+
+    # Reset any invalid motif
+    execute <<~SQL.squish
+      UPDATE  reports
+      SET     state = 'assigned', resolution_motif = NULL
+      WHERE   resolution_motif IN ('maj_occupation', 'application_majoration_ths')
+    SQL
 
     change_column :reports, :resolution_motif, :enum,
       enum_type: :resolution_motif,

--- a/spec/factories/reports.rb
+++ b/spec/factories/reports.rb
@@ -227,8 +227,11 @@ FactoryBot.define do
     trait :made_for_office do
       made_for_ddfip
 
+      # Exclude `occupation_local_professionnel` because it cannot be resolved yet,
+      # due to lack of motifs (see :resolved trait)
+      #
       transient do
-        competence { Office::COMPETENCES.sample }
+        competence { Office::COMPETENCES.without("occupation_local_professionnel").sample }
       end
 
       office    { association(:office, :with_communes, ddfip:, competences: [competence]) }
@@ -237,60 +240,60 @@ FactoryBot.define do
     end
 
     trait :transmitted_to_ddfip do
-      made_for_ddfip
       transmitted
+      made_for_ddfip
     end
 
     # Report workflow by DDFIP & offices
     # --------------------------------------------------------------------------
     trait :acknowledged_by_ddfip do
-      made_for_ddfip
       acknowledged
+      made_for_ddfip
     end
 
     trait :accepted_by_ddfip do
-      made_for_ddfip
       accepted
+      made_for_ddfip
     end
 
     trait :assigned_by_ddfip do
-      made_for_ddfip
       assigned
+      made_for_ddfip
     end
 
     trait :assigned_to_office do
-      made_for_office
       assigned
+      made_for_office
     end
 
     trait :resolved_by_ddfip do
-      assigned_by_ddfip
       resolved
+      made_for_ddfip
     end
 
     trait :resolved_as_applicable do
-      assigned_to_office
       applicable
+      made_for_office
     end
 
     trait :resolved_as_inapplicable do
-      assigned_to_office
       inapplicable
+      made_for_office
     end
 
     trait :approved_by_ddfip do
-      resolved_as_applicable
       approved
+      made_for_office
     end
 
     trait :canceled_by_ddfip do
-      resolved_as_inapplicable
       canceled
+      made_for_office
     end
 
     trait :rejected_by_ddfip do
-      made_for_ddfip
       rejected
+      made_for_office
     end
   end
 end

--- a/spec/requests/reports/resolutions/update_spec.rb
+++ b/spec/requests/reports/resolutions/update_spec.rb
@@ -11,10 +11,11 @@ RSpec.describe "Reports::ResolutionsController#update" do
   let(:headers) { |e| e.metadata[:headers] }
   let(:params)  { |e| e.metadata.fetch(:params, { state: state, report: attributes }) }
 
-  let!(:report) { create(:report, :assigned_to_office) }
+  let!(:report) { create(:report, :assigned_to_office, competence:) }
 
   let(:state)      { "applicable" }
   let(:attributes) { { reponse: "Lorem lipsum", resolution_motif: "maj_local" } }
+  let(:competence) { "evaluation_local_habitation" }
 
   describe "authorizations" do
     it_behaves_like "it requires to be signed in in HTML"
@@ -29,7 +30,7 @@ RSpec.describe "Reports::ResolutionsController#update" do
     it_behaves_like "it denies access to collectivity admin"
 
     context "when report has been assigned by the current DDFIP" do
-      let(:report) { create(:report, :assigned_to_office, ddfip: current_user.organization) }
+      let(:report) { create(:report, :assigned_to_office, ddfip: current_user.organization, competence:) }
 
       it_behaves_like "it allows access to DDFIP user"
       it_behaves_like "it allows access to DDFIP admin"
@@ -43,21 +44,21 @@ RSpec.describe "Reports::ResolutionsController#update" do
     end
 
     context "when report has already been resolved by the current DDFIP" do
-      let(:report) { create(:report, :resolved_as_applicable, ddfip: current_user.organization) }
+      let(:report) { create(:report, :resolved_as_applicable, ddfip: current_user.organization, competence:) }
 
       it_behaves_like "it allows access to DDFIP user"
       it_behaves_like "it allows access to DDFIP admin"
     end
 
     context "when report has already been approved by the current DDFIP" do
-      let(:report) { create(:report, :approved_by_ddfip, ddfip: current_user.organization) }
+      let(:report) { create(:report, :approved_by_ddfip, ddfip: current_user.organization, competence:) }
 
       it_behaves_like "it denies access to DDFIP user"
       it_behaves_like "it denies access to DDFIP admin"
     end
 
     context "when report has already been canceled by the current DDFIP" do
-      let(:report) { create(:report, :canceled_by_ddfip, ddfip: current_user.organization) }
+      let(:report) { create(:report, :canceled_by_ddfip, ddfip: current_user.organization, competence:) }
 
       it_behaves_like "it denies access to DDFIP user"
       it_behaves_like "it denies access to DDFIP admin"
@@ -120,7 +121,7 @@ RSpec.describe "Reports::ResolutionsController#update" do
     end
 
     context "when inapplicable report is going to be resolved as applicable" do
-      let!(:report) { create(:report, :resolved_as_inapplicable) }
+      let!(:report) { create(:report, :resolved_as_inapplicable, competence:) }
 
       it { expect(response).to have_http_status(:see_other) }
       it { expect(response).to redirect_to("/signalements/#{report.id}") }
@@ -146,8 +147,7 @@ RSpec.describe "Reports::ResolutionsController#update" do
     end
 
     context "when applicable report is going to be resolved as inapplicable" do
-      let!(:report) { create(:report, :resolved_as_applicable) }
-      let(:state)   { "inapplicable" }
+      let(:state)      { "inapplicable" }
       let(:attributes) { { reponse: "Lorem lipsum", resolution_motif: "absence_incoherence" } }
 
       it { expect(response).to have_http_status(:see_other) }

--- a/spec/services/reports/states/resolve_service_spec.rb
+++ b/spec/services/reports/states/resolve_service_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Reports::States::ResolveService do
     described_class.new(report)
   end
 
-  let(:report) { create(:report, :assigned_to_office) }
+  let(:report) { create(:report, :evaluation_local_habitation, :assigned) }
 
   describe "#resolve" do
     context "when resolving an assigned report as applicable" do
@@ -62,7 +62,7 @@ RSpec.describe Reports::States::ResolveService do
     end
 
     context "when report is already resolved" do
-      let(:report) { create(:report, :resolved_as_applicable) }
+      let(:report) { create(:report, :applicable) }
 
       it "updates the report resolution" do
         expect { service.resolve(:inapplicable, resolution_motif: "absence_incoherence") }
@@ -113,7 +113,7 @@ RSpec.describe Reports::States::ResolveService do
 
   describe "#undo" do
     context "when report is resolved" do
-      let(:report) { create(:report, :assigned, :applicable) }
+      let(:report) { create(:report, :applicable) }
 
       it "updates the report back as assigned" do
         expect { service.undo }


### PR DESCRIPTION
Implémentation des motifs de résolution en fonction du type de formulaire : 

En cas d'avis favorable, les motifs sont :

* Evaluation/création d'un local (habitation/professionnel)
  * "Descriptif du local mis à jour"
  * "Exonérations mises à jour"
  * "Signalement en doublon, déjà pris en charge "

* Occupation d'un local d'habitation :
  * "Occupation du local mise à jour"
  * "Application de la majoration THS"

En cas d'avis défavorable, un seul motif est disponible dans tout les cas : 
* "Aucune incohérence décelée"

Aucun motif n'est pour le moment disponible en réponse au formulaire d'occupation d'un local professionnel tant que l'expérimentation n'a pas démarrée.

---
Cette PR dépends de :
* #15 
