### PR TITLE
Validation d'un signalement

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,7 +52,7 @@ Layout/LineLength:
     - !ruby/regexp /\A\s*has_one/
     - !ruby/regexp /\A\s*scope/
     - !ruby/regexp /\A\s*resources?/
-    - !ruby/regexp /\A\s*validates_.+/
+    - !ruby/regexp /\A\s*validates(_|\s).+/
     - !ruby/regexp /\A\s*def [a-z_?!]+\s*= .+/
 
 Layout/MultilineMethodCallIndentation:

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -20,6 +20,9 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class        = true
   self.implicit_order_column = :created_at
 
+  ANNEE_MINIMUM = 2018
+  CURRENT_YEAR  = ->(_) { Time.current.year }
+
   SIREN_REGEXP  = /\A[0-9]{9}\Z/
   PHONE_REGEXP  = /\A(0|\+(33|590|594|596|262|269))?[0-9]{9}\Z/
   EMAIL_REGEXP  = URI::MailTo::EMAIL_REGEXP
@@ -32,8 +35,8 @@ class ApplicationRecord < ActiveRecord::Base
 
   INVARIANT_REGEXP                 = /\A[0-9]{10}\Z/
   CODE_RIVOLI_REGEXP               = /\A[0-9A-Z]{4}\Z/
-  NUMERO_BATIMENT_REGEXP           = /\A(?:[A-Z]|[0-9]{1,2})\Z/
-  NUMERO_ESCALIER_REGEXP           = /\A[0-9]{1,2}\Z/
+  NUMERO_BATIMENT_REGEXP           = /\A(?:[A-Z0-9]{1,2})\Z/
+  NUMERO_ESCALIER_REGEXP           = /\A(?:[A-Z0-9]{1,2})\Z/
   NUMERO_NIVEAU_REGEXP             = /\A[0-9]{1,2}\Z/
   NUMERO_PORTE_REGEXP              = /\A[0-9]{1,2}\Z/
   NUMERO_ORDRE_PORTE_REGEXP        = /\A[0-9]{1,3}\Z/

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -240,10 +240,7 @@ class Report < ApplicationRecord
   validates :resolution_motif, inclusion: { in: RESOLUTION_MOTIFS, allow_blank: true }
 
   with_options allow_blank: true do
-    validates :situation_annee_majic, numericality: {
-      greater_than_or_equal_to: 2018,
-      less_than_or_equal_to:    ->(_) { Time.current.year }
-    }
+    validates :situation_annee_majic, numericality: { greater_than_or_equal_to: ANNEE_MINIMUM, less_than_or_equal_to: CURRENT_YEAR }
 
     validates :code_insee,                          format: { with: CODE_INSEE_REGEXP }
     validates :situation_invariant,                 format: { with: INVARIANT_REGEXP }
@@ -292,15 +289,16 @@ class Report < ApplicationRecord
     validates :proposition_surface_pk2,      numericality: { greater_than_or_equal_to: 0 }
     validates :proposition_surface_ponderee, numericality: { greater_than: 0 }
 
-    validates :situation_occupation_annee,       numericality: { in: 2018..Time.current.year }
+    validates :situation_occupation_annee,       numericality: { greater_than_or_equal_to: ANNEE_MINIMUM, less_than_or_equal_to: CURRENT_YEAR }
+    validates :situation_annee_cfe,              numericality: { greater_than_or_equal_to: ANNEE_MINIMUM, less_than_or_equal_to: CURRENT_YEAR }
+    validates :situation_nombre_annees_vacance,  numericality: { greater_than_or_equal_to: 0 }
+    validates :situation_vlf_cfe,                numericality: { greater_than_or_equal_to: 0 }
+
     validates :situation_nature_occupation,      inclusion: { in: :valid_occupations }
     validates :situation_majoration_rs,          inclusion: [true, false]
-    validates :situation_annee_cfe,              numericality: { in: 2018..Time.current.year }
     validates :situation_vacance_fiscale,        inclusion: [true, false]
-    validates :situation_nombre_annees_vacance,  numericality: { greater_than_or_equal_to: 0 }
-    validates :situation_siren_dernier_occupant, format: { with: SIREN_REGEXP }
-    validates :situation_vlf_cfe,                numericality: { greater_than_or_equal_to: 0 }
     validates :situation_taxation_base_minimum,  inclusion: [true, false]
+    validates :situation_siren_dernier_occupant, format: { with: SIREN_REGEXP }
 
     validates :proposition_nature_occupation,          inclusion: { in: :valid_occupations }
     validates :proposition_erreur_tlv,                 inclusion: [true, false]


### PR DESCRIPTION
Les champs `*_numero_batiment` et `*_numero_escalier` acceptent des lettres et/ou des chiffres.

Les champs de type année ne peuvent pas recevoir d'années futures.