### PR TITLE
Rendre la nature d'occupation actuelle optionnelle pour les locaux d'habitation

### DIFF
--- a/app/services/reports/requirements_service.rb
+++ b/app/services/reports/requirements_service.rb
@@ -625,15 +625,17 @@ module Reports
 
       # @attribute situation_nature_occupation
       #
-      # This attribute is displayed and required for:
+      # This attribute is displayed for:
       # * any `occupation_local_habitation` form
+      #
+      # It is not required
       #
       def display_situation_nature_occupation?
         occupation_local_habitation?
       end
 
       def require_situation_nature_occupation?
-        display_situation_nature_occupation?
+        false
       end
 
       # @attribute situation_majoration_rs

--- a/app/views/documentation/api/guides/formulaire_occupation_local_habitation/_occupation.html.slim
+++ b/app/views/documentation/api/guides/formulaire_occupation_local_habitation/_occupation.html.slim
@@ -96,7 +96,6 @@ table
       td <code>RP</code>, <code>RS</code>, <code>RE</code>
       td = link_to "Consulter toutes les valeurs", "/api/documentation/guides/local_nature_occupation.csv"
       td.text-right.space-x-4
-        .badge.badge--orange.badge--mono requis
         .badge.badge--blue.badge--mono String
     tr
       th <code>situation_majoration_rs</code>

--- a/spec/services/reports/requirements_service_spec.rb
+++ b/spec/services/reports/requirements_service_spec.rb
@@ -1276,7 +1276,7 @@ RSpec.describe Reports::RequirementsService do
     it { is_expected.not_to be_display_situation_taxation_base_minimum }
 
     it { is_expected.to     be_require_situation_occupation_annee }
-    it { is_expected.to     be_require_situation_nature_occupation }
+    it { is_expected.not_to be_require_situation_nature_occupation }
     it { is_expected.not_to be_require_situation_majoration_rs }
     it { is_expected.not_to be_require_situation_annee_cfe }
     it { is_expected.not_to be_require_situation_vacance_fiscale }
@@ -1346,7 +1346,7 @@ RSpec.describe Reports::RequirementsService do
       it { is_expected.not_to be_display_situation_taxation_base_minimum }
 
       it { is_expected.to     be_require_situation_occupation_annee }
-      it { is_expected.to     be_require_situation_nature_occupation }
+      it { is_expected.not_to be_require_situation_nature_occupation }
       it { is_expected.not_to be_require_situation_majoration_rs }
       it { is_expected.not_to be_require_situation_annee_cfe }
       it { is_expected.not_to be_require_situation_vacance_fiscale }
@@ -1377,7 +1377,7 @@ RSpec.describe Reports::RequirementsService do
       it { is_expected.not_to be_display_situation_taxation_base_minimum }
 
       it { is_expected.to     be_require_situation_occupation_annee }
-      it { is_expected.to     be_require_situation_nature_occupation }
+      it { is_expected.not_to be_require_situation_nature_occupation }
       it { is_expected.to     be_require_situation_majoration_rs }
       it { is_expected.not_to be_require_situation_annee_cfe }
       it { is_expected.not_to be_require_situation_vacance_fiscale }
@@ -1415,7 +1415,7 @@ RSpec.describe Reports::RequirementsService do
       it { is_expected.not_to be_display_situation_taxation_base_minimum }
 
       it { is_expected.to     be_require_situation_occupation_annee }
-      it { is_expected.to     be_require_situation_nature_occupation }
+      it { is_expected.not_to be_require_situation_nature_occupation }
       it { is_expected.not_to be_require_situation_majoration_rs }
       it { is_expected.not_to be_require_situation_annee_cfe }
       it { is_expected.not_to be_require_situation_vacance_fiscale }


### PR DESCRIPTION
Le champs `situation_nature_occupation` devient optionel pour compléter le formulaire "Occupation d'un local d'habitation"