### PR TITLE
Set random encryption keys to run CI without master key

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -73,4 +73,8 @@ Rails.application.configure do
   # Set an alternative log file
   # Useful for running `bin/ci watch` and `bin/ci` in parallel
   config.logger = ActiveSupport::Logger.new(ENV["LOG_PATH"]) if ENV["LOG_PATH"]
+
+  # Generate random keys for ActiveRecord encryption
+  config.active_record.encryption.primary_key         = SecureRandom.alphanumeric(32)
+  config.active_record.encryption.key_derivation_salt = SecureRandom.alphanumeric(32)
 end


### PR DESCRIPTION
Cette PR ajoute des clés aléatoires pour configurer ActiveRecord Encryption en test sans avoir besoin de la master key (ce qui sera le cas pour des PR via un fork)
