### PR TITLE
Timeline des signalements

### DIFF
--- a/app/assets/stylesheets/application.postcss.css
+++ b/app/assets/stylesheets/application.postcss.css
@@ -35,6 +35,7 @@
 @import "../../components/ui/description_list";
 @import "../../components/ui/modal";
 @import "../../components/ui/table";
+@import "../../components/ui/timeline";
 
 /* UI components - may depends on top components */
 @import "../../components/ui/badge";

--- a/app/components/ui/timeline/component.html.slim
+++ b/app/components/ui/timeline/component.html.slim
@@ -1,0 +1,3 @@
+ul.timeline*@html_attributes
+  - steps.each do |step|
+    = step

--- a/app/components/ui/timeline/component.rb
+++ b/app/components/ui/timeline/component.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module UI
+  module Timeline
+    class Component < ApplicationViewComponent
+      define_component_helper :timeline_component
+      renders_many :steps, ->(*args, **kwargs) { Step.new(self, *args, **kwargs) }
+
+      attr_reader :date_format
+
+      def initialize(date_format: nil, **)
+        @date_format     = date_format || I18n.t("date.formats.default")
+        @html_attributes = parse_html_attributes(**)
+        super()
+      end
+    end
+  end
+end

--- a/app/components/ui/timeline/component/step.html.slim
+++ b/app/components/ui/timeline/component/step.html.slim
@@ -1,0 +1,20 @@
+li.timeline-step( *html_attributes )
+  .timeline-step__marker
+    - if icon
+      = icon_component icon, set: :heroicon, variant: :solid
+
+  .timeline-step__content
+    - if date
+      .timeline-step__date
+        - if date.is_a?(String)
+          = date
+        - else
+          = l(date, format: date_format)
+
+    - if title
+      .timeline-step__title
+        = title
+
+    - if content
+      .timeline-step__description
+        = content

--- a/app/components/ui/timeline/component/step.rb
+++ b/app/components/ui/timeline/component/step.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module UI
+  module Timeline
+    class Component
+      class Step < ApplicationViewComponent
+        CSS_CLASSES = {
+          pending:  "timeline-step--pending",
+          current:  "timeline-step--current",
+          done:     "timeline-step--done",
+          failed:   "timeline-step--failed"
+        }.freeze
+
+        attr_reader :title, :description, :status, :date, :icon
+
+        delegate :date_format, to: :@timeline
+
+        def initialize(timeline, title, status: :pending, date: nil, icon: nil, **)
+          status = status.to_sym if status.is_a?(String)
+          raise ArgumentError, "unexpected status: #{status.inspect}" unless CSS_CLASSES.include?(status)
+
+          @timeline        = timeline
+          @title           = title
+          @status          = status
+          @date            = date
+          @icon            = icon
+          @html_attributes = parse_html_attributes(**)
+          super()
+        end
+
+        def html_attributes
+          reverse_merge_attributes(@html_attributes, {
+            class: CSS_CLASSES.fetch(@status)
+          })
+        end
+      end
+    end
+  end
+end

--- a/app/components/ui/timeline/index.css
+++ b/app/components/ui/timeline/index.css
@@ -1,0 +1,125 @@
+@layer components {
+  /* Default style */
+  .timeline {
+    display: flex;
+    flex-direction: column;
+
+    @apply gap-6;
+  }
+
+  .timeline-step {
+    display: flex;
+    @apply gap-4;
+  }
+
+  .timeline-step__marker {
+    display:         flex;
+    flex-direction:  column;
+    justify-content: center;
+    align-items:     center;
+
+    @apply min-w-6 gap-2;
+
+    & svg {
+      display:    block;
+      flex:       none;
+
+      @apply size-6 p-1;
+      @apply rounded-full;
+    }
+
+    &:not(:has(svg)):before {
+      content:    "";
+      display:    block;
+      flex:       none;
+
+      @apply size-6 border-4 rounded-full;
+    }
+
+    &:after {
+      content:    "";
+      display:    block;
+      flex:       1;
+
+      @apply size-0 border-2 rounded-full;
+    }
+
+    & svg,
+    &:not(:has(svg)):before,
+    &:after {
+      @apply text-white bg-gray-400 border-gray-300;
+      @apply dark:border-gray-600;
+    }
+  }
+
+  .timeline-step__content {
+    display:        flex;
+    flex-direction: column;
+
+    @apply gap-2 pb-1;
+  }
+
+  .timeline-step__date {
+    @apply text-base leading-6;
+
+    @apply text-gray-600;
+    @apply dark:text-gray-400;
+  }
+
+  .timeline-step__title {
+    @apply text-lg font-medium leading-6;
+
+    @apply text-gray-900;
+    @apply dark:text-gray-100;
+  }
+
+  .timeline-step__description {
+    @apply text-base;
+  }
+
+  /* Done variations */
+  .timeline-step--done {
+    & .timeline-step__marker svg,
+    & .timeline-step__marker:before,
+    & .timeline-step__marker:after {
+      @apply bg-green-400 border-green-200;
+      @apply dark:border-lime-800;
+    }
+  }
+
+  /* Stopped variations */
+  .timeline-step--failed {
+    & .timeline-step__marker svg,
+    & .timeline-step__marker:before,
+    & .timeline-step__marker:after {
+      @apply bg-red-400 border-red-200;
+      @apply dark:border-red-800;
+    }
+  }
+
+  /* In progress variations */
+  .timeline-step--current {
+    & .timeline-step__marker svg,
+    & .timeline-step__marker:before,
+    & .timeline-step__marker:after {
+      @apply bg-violet-400 border-violet-200;
+      @apply dark:border-violet-800;
+    }
+  }
+
+  @media (width >= 48rem) {
+    .timeline--horizontal {
+      &,
+      & .timeline-step__marker {
+        flex-direction: row;
+      }
+
+      & .timeline-step {
+        flex-direction: column;
+
+        @apply flex-1;
+      }
+    }
+  }
+}
+

--- a/app/components/ui/timeline/index.css
+++ b/app/components/ui/timeline/index.css
@@ -82,7 +82,7 @@
     & .timeline-step__marker svg,
     & .timeline-step__marker:before,
     & .timeline-step__marker:after {
-      @apply bg-green-400 border-green-200;
+      @apply bg-lime-500 border-lime-300;
       @apply dark:border-lime-800;
     }
   }

--- a/app/components/ui/timeline/preview.rb
+++ b/app/components/ui/timeline/preview.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module UI
+  module Timeline
+    # @display frame "content"
+    #
+    class Preview < ApplicationViewComponentPreview
+      # @label Default
+      #
+      def default; end
+
+      # @label Horizontal
+      #
+      def horizontal; end
+
+      # @label With icons
+      #
+      def with_icons; end
+    end
+  end
+end

--- a/app/components/ui/timeline/previews/default.html.slim
+++ b/app/components/ui/timeline/previews/default.html.slim
@@ -1,0 +1,15 @@
+= timeline_component do |timeline|
+  - timeline.with_step("Etape 1", status: :done, date: Date.new(2024, 1, 1))
+
+  - timeline.with_step("Etape 2", status: :done, date: Date.new(2024, 1, 5)) do
+    ' Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+  - timeline.with_step("Etape 3", status: :current) do
+    ' Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
+    ' totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+
+  - timeline.with_step("Etape 4") do
+    ' Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+    ' dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
+    ' consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam
+    ' quaerat voluptatem.

--- a/app/components/ui/timeline/previews/horizontal.html.slim
+++ b/app/components/ui/timeline/previews/horizontal.html.slim
@@ -1,0 +1,16 @@
+= timeline_component(class: "timeline--horizontal") do |timeline|
+  - timeline.with_step("Etape 1", status: :done, date: Date.new(2024, 1, 1))
+    ' Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+  - timeline.with_step("Etape 2", status: :done, date: Date.new(2024, 1, 5)) do
+    ' Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+  - timeline.with_step("Etape 3", status: :current) do
+    ' Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
+    ' totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+
+  - timeline.with_step("Etape 4") do
+    ' Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+    ' dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
+    ' consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam
+    ' quaerat voluptatem.

--- a/app/components/ui/timeline/previews/with_icons.html.slim
+++ b/app/components/ui/timeline/previews/with_icons.html.slim
@@ -1,0 +1,16 @@
+= timeline_component do |timeline|
+  - timeline.with_step("Etape 1", icon: "check", status: :done, date: Date.new(2024, 1, 1)) do
+    ' Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+
+  - timeline.with_step("Etape 2", icon: "check", status: :done, date: Date.new(2024, 1, 5)) do
+    ' Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+  - timeline.with_step("Etape 3", icon: "envelope", status: :current) do
+    ' Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium,
+    ' totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+
+  - timeline.with_step("Etape 4", icon: "envelope-open") do
+    ' Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+    ' dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet,
+    ' consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam
+    ' quaerat voluptatem.

--- a/app/components/views/reports/show/component.html.slim
+++ b/app/components/views/reports/show/component.html.slim
@@ -3,15 +3,15 @@
     - layout.with_breadcrumbs do
       = render Views::Reports::Show::Breadcrumbs::Component.new(@report)
 
-    - layout.with_section do
-      = render Views::Reports::Show::Timeline::Component.new(@report)
-
     - if @report.packing?
       - layout.with_section do
         = render InformationPacking.new(@report)
     - else
       - layout.with_section do
         = render InformationTransmitted.new(@report)
+
+    - layout.with_section do
+      = render Views::Reports::Show::Timeline::Component.new(@report)
 
     - if current_organization.is_a?(DDFIP) || current_organization.is_a?(DGFIP)
       - layout.with_grid do |grid|

--- a/app/components/views/reports/show/component.html.slim
+++ b/app/components/views/reports/show/component.html.slim
@@ -3,6 +3,9 @@
     - layout.with_breadcrumbs do
       = render Views::Reports::Show::Breadcrumbs::Component.new(@report)
 
+    - layout.with_section do
+      = render Views::Reports::Show::Timeline::Component.new(@report)
+
     - if @report.packing?
       - layout.with_section do
         = render InformationPacking.new(@report)

--- a/app/components/views/reports/show/timeline/component.fr.yml
+++ b/app/components/views/reports/show/timeline/component.fr.yml
@@ -140,3 +140,38 @@ fr:
       canceled:
         status:     "done"
         text:       "La collectivité a reçu un retour négatif"
+
+  ddfip_user:
+    assigned:
+      title:        "Reception du signalement"
+      text:         "Le signalement a été assigné au guichet %{office}"
+      status:       "done"
+
+    applicable:
+      title:        "Traitement validé"
+      text:         "Le signalement a été accepté par le guichet avec le motif « %{motif} »"
+      status:       "done"
+      assigned:     &current
+        title:      "Résolution du signalement"
+        status:     "current"
+        text:       "Le signalement est prêt à être traité"
+      inapplicable: &failed
+        status:     "failed"
+        title:      "Traitement annulé"
+        text:       "Le guichet a refusé le signalement pour le motif « %{motif} »"
+      canceled:     *failed
+
+    approved:
+      title:        "Réponse à la collectivité"
+      text:         "La collectivité a reçu un retour positif"
+      status:       "done"
+      assigned:
+        status:     "pending"
+        text:       "La collectivité n'a pas reçu de retour concernant ce signalement"
+      applicable:   &current
+        status:     "current"
+        text:       "La réponse du guichet sera transmise à la collectivité une fois confirmée par le référent fiabilisation"
+      inapplicable: *current
+      canceled:
+        status:     "done"
+        text:       "La collectivité a reçu un retour négatif"

--- a/app/components/views/reports/show/timeline/component.fr.yml
+++ b/app/components/views/reports/show/timeline/component.fr.yml
@@ -66,3 +66,77 @@ fr:
       canceled:
         status:     "failed"
         text:       "La DDFIP a donné une réponse négative à ce signalement"
+
+  ddfip_admin:
+    accepted:
+      title:        "Acceptation du signalement"
+      text:         "Le signalement a été accepté"
+      status:       "done"
+      transmitted:  &current
+        status:     "current"
+        text:       "Le signalement n'a pas encore été accepté ou rejeté"
+      acknowledged: *current
+      rejected:
+        status:     "failed"
+        title:      "Rejet du signalement"
+        text:       "Le signalement a été rejeté. Des observations ont pu être transmises à la collectivité"
+
+    assigned:
+      title:        "Assignation à un guichet"
+      text:         "Le signalement a été assigné au guichet %{office}"
+      status:       "done"
+      transmitted:  &pending
+        status:     "pending"
+        text:       "Le signalement pourra être assigné à un guichet s'il est accepté"
+      acknowledged: *pending
+      accepted:     &current
+        status:     "current"
+        text:       "Le signalement a été accepté et est prêt à être assigné à un guichet"
+      rejected:
+        status:     "failed"
+        text:       "Un signalement rejeté ne peut être assigné à un guichet"
+
+    applicable:
+      title:        "Signalement validé par le guichet"
+      text:         "Le signalement a été accepté par le guichet avec le motif « %{motif} »"
+      status:       "done"
+      transmitted:  &pending
+        title:      "Résolution du signalement"
+        status:     "pending"
+        text:       "Le signalement pourra être accepté lorsqu'il sera traité par le guichet"
+      acknowledged: *pending
+      accepted:     *pending
+      rejected:
+        title:      "Résolution du signalement"
+        status:     "failed"
+        text:       "Aucun guichet n'a pu se prononcer concernant ce signalement"
+      assigned:     &current
+        title:      "Résolution du signalement"
+        status:     "current"
+        text:       "Le guichet n'a pas encore traité ce signalement"
+      inapplicable: &failed
+        status:     "failed"
+        title:      "Signalement rejeté par le guichet"
+        text:       "Le guichet a refusé le signalement pour le motif « %{motif} »"
+      canceled:     *failed
+
+    approved:
+      title:        "Réponse à la collectivité"
+      text:         "La collectivité a reçu un retour positif"
+      status:       "done"
+      transmitted:  &pending
+        status:     "pending"
+        text:       "La collectivité n'a pas reçu de retour concernant ce signalement"
+      acknowledged: *pending
+      accepted:     *pending
+      assigned:     *pending
+      rejected:
+        status:     "failed"
+        text:       "La collectivité a été notifiée du rejet de ce signalement"
+      applicable:   &current
+        status:     "current"
+        text:       "La réponse du guichet sera transmise à la collectivité une fois confirmée par le référent fiabilisation"
+      inapplicable: *current
+      canceled:
+        status:     "done"
+        text:       "La collectivité a reçu un retour négatif"

--- a/app/components/views/reports/show/timeline/component.fr.yml
+++ b/app/components/views/reports/show/timeline/component.fr.yml
@@ -1,0 +1,68 @@
+fr:
+  collectivity:
+    ready:
+      title:        "Formulaire complété"
+      text:         "Le formulaire de signalement a été complété"
+      status:       "done"
+      draft:
+        title:      "Complétion du formulaire"
+        status:     "current"
+        text:       "En attente de la complétion du formulaire"
+
+    transmitted:
+      title:        "Signalement transmis"
+      text:         "Le signalement a été transmis à la DDFIP"
+      status:       "done"
+      draft:
+        title:      "Transmission du signalement"
+        status:     "pending"
+        text:       "Le signalement pourra être transmis à la DDFIP une fois le formulaire complété"
+      ready:
+        title:      "Transmission du signalement"
+        status:     "current"
+        text:       "Le signalement est prêt à être transmis à la DDFIP"
+      in_active_transmission:
+        title:      "Transmission du signalement"
+        status:     "current"
+        text:       "La transmission du signalement est en attente"
+
+    accepted:
+      title:        "Acceptation du signalement"
+      text:         "La DDFIP pourra accepter ou refuser de traiter le signalement lorsqu'il sera transmis"
+      status:       "pending"
+      transmitted:  &current
+        status:     "current"
+        text:       "La DDFIP a reçu le signalement et va le traiter prochainement"
+      acknowledged: *current
+      accepted:     &done
+        title:      "Signalement accepté"
+        status:     "done"
+        text:       "La DDFIP a reçu le signalement et accepté son traitement"
+      assigned:     *done
+      applicable:   *done
+      inapplicable: *done
+      approved:     *done
+      canceled:     *done
+      rejected:
+        status:     "failed"
+        title:      "Signalement rejeté"
+        text:       "La DDFIP a rejeté le traitement du signalement"
+
+    approved:
+      title:        "Réponse de la DDFIP"
+      text:         "La DDFIP n'a pas encore répondu à propos de ce signalement"
+      status:       "pending"
+      accepted:     &current
+        status:     "current"
+      assigned:     *current
+      applicable:   *current
+      inapplicable: *current
+      rejected:
+        status:     "failed"
+        text:       "La DDFIP a rejeté le traitement du signalement"
+      approved:
+        status:     "done"
+        text:       "La DDFIP a donné une réponse positive à ce signalement"
+      canceled:
+        status:     "failed"
+        text:       "La DDFIP a donné une réponse négative à ce signalement"

--- a/app/components/views/reports/show/timeline/component.html.slim
+++ b/app/components/views/reports/show/timeline/component.html.slim
@@ -1,0 +1,13 @@
+- if viewer_type == :collectivity
+  = timeline_component(class: "timeline--horizontal") do |timeline|
+    = timeline.with_step step_title("collectivity", "ready"), status: step_status("collectivity", "ready"), date: @report.completed_at do
+      = step_text("collectivity", "ready")
+
+    = timeline.with_step step_title("collectivity", "transmitted"), status: step_status("collectivity", "transmitted"), date: @report.transmitted_at do
+      = step_text("collectivity", "transmitted")
+
+    = timeline.with_step step_title("collectivity", "accepted"), status: step_status("collectivity", "accepted"), date: @report.accepted_at || @report.returned_at do
+      = step_text("collectivity", "accepted")
+
+    = timeline.with_step step_title("collectivity", "approved"), status: step_status("collectivity", "approved"), date: @report.returned_at do
+      = step_text("collectivity", "approved")

--- a/app/components/views/reports/show/timeline/component.html.slim
+++ b/app/components/views/reports/show/timeline/component.html.slim
@@ -11,3 +11,18 @@
 
     = timeline.with_step step_title("collectivity", "approved"), status: step_status("collectivity", "approved"), date: @report.returned_at do
       = step_text("collectivity", "approved")
+
+- if viewer_type == :ddfip_admin
+  = timeline_component(class: "timeline--horizontal") do |timeline|
+    = timeline.with_step step_title("ddfip_admin", "accepted"), status: step_status("ddfip_admin", "accepted"), date: @report.accepted_at || @report.returned_at do
+      = step_text("ddfip_admin", "accepted")
+
+    = timeline.with_step step_title("ddfip_admin", "assigned"), status: step_status("ddfip_admin", "assigned"), date: @report.assigned_at do
+      = step_text("ddfip_admin", "assigned", office: @report.office&.name)
+
+    = timeline.with_step step_title("ddfip_admin", "applicable"), status: step_status("ddfip_admin", "applicable"), date: @report.resolved_at do
+      = step_text("ddfip_admin", "applicable", motif: translate_enum(@report.resolution_motif, scope: "enum.resolution_motif"))
+
+    = timeline.with_step step_title("ddfip_admin", "approved"), status: step_status("ddfip_admin", "approved"), date: @report.returned_at do
+      = step_text("ddfip_admin", "approved")
+

--- a/app/components/views/reports/show/timeline/component.html.slim
+++ b/app/components/views/reports/show/timeline/component.html.slim
@@ -12,7 +12,7 @@
     = timeline.with_step step_title("collectivity", "approved"), status: step_status("collectivity", "approved"), date: @report.returned_at do
       = step_text("collectivity", "approved")
 
-- if viewer_type == :ddfip_admin
+- elsif viewer_type == :ddfip_admin
   = timeline_component(class: "timeline--horizontal") do |timeline|
     = timeline.with_step step_title("ddfip_admin", "accepted"), status: step_status("ddfip_admin", "accepted"), date: @report.accepted_at || @report.returned_at do
       = step_text("ddfip_admin", "accepted")
@@ -26,3 +26,13 @@
     = timeline.with_step step_title("ddfip_admin", "approved"), status: step_status("ddfip_admin", "approved"), date: @report.returned_at do
       = step_text("ddfip_admin", "approved")
 
+- elsif viewer_type == :ddfip_user
+  = timeline_component(class: "timeline--horizontal") do |timeline|
+    = timeline.with_step step_title("ddfip_user", "assigned"), status: step_status("ddfip_user", "assigned"), date: @report.assigned_at do
+      = step_text("ddfip_user", "assigned", office: @report.office&.name)
+
+    = timeline.with_step step_title("ddfip_user", "applicable"), status: step_status("ddfip_user", "applicable"), date: @report.resolved_at do
+      = step_text("ddfip_user", "applicable", motif: translate_enum(@report.resolution_motif, scope: "enum.resolution_motif"))
+
+    = timeline.with_step step_title("ddfip_user", "approved"), status: step_status("ddfip_user", "approved"), date: @report.returned_at do
+      = step_text("ddfip_user", "approved")

--- a/app/components/views/reports/show/timeline/component.rb
+++ b/app/components/views/reports/show/timeline/component.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Views
+  module Reports
+    module Show
+      module Timeline
+        class Component < ApplicationViewComponent
+          def initialize(report)
+            @report = report
+            super()
+          end
+
+          def step_title(viewer_type, step)
+            t(".#{viewer_type}.#{step}.#{report_state}.title", default: t(".#{viewer_type}.#{step}.title"))
+          end
+
+          def step_status(viewer_type, step)
+            t(".#{viewer_type}.#{step}.#{report_state}.status", default: t(".#{viewer_type}.#{step}.status"))
+          end
+
+          def step_text(viewer_type, step)
+            t(".#{viewer_type}.#{step}.#{report_state}.text", default: t(".#{viewer_type}.#{step}.text"))
+          end
+
+          def viewer_type
+            case current_organization&.model_name&.element
+            when "collectivity", "publisher" then :collectivity
+            when "dgfip", "ddfip_admin"      then :ddfip_admin
+            when "ddfip_user"                then :ddfip_user
+            when "ddfip"                     then current_user.organization_admin? ? :ddfip_admin : :ddfip_user
+            end
+          end
+
+          def report_state
+            @report_state ||=
+              if viewer_type == :collectivity
+                if @report.packing? && @report.in_active_transmission?
+                  :in_active_transmission
+                else
+                  @report.state
+                end
+              else
+                @report.state
+              end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/views/reports/show/timeline/component.rb
+++ b/app/components/views/reports/show/timeline/component.rb
@@ -18,8 +18,8 @@ module Views
             t(".#{viewer_type}.#{step}.#{report_state}.status", default: t(".#{viewer_type}.#{step}.status"))
           end
 
-          def step_text(viewer_type, step)
-            t(".#{viewer_type}.#{step}.#{report_state}.text", default: t(".#{viewer_type}.#{step}.text"))
+          def step_text(viewer_type, step, options = {})
+            t(".#{viewer_type}.#{step}.#{report_state}.text", default: t(".#{viewer_type}.#{step}.text"), **options)
           end
 
           def viewer_type
@@ -42,6 +42,10 @@ module Views
               else
                 @report.state
               end
+          end
+
+          def translate_enum(value, **)
+            I18n.t(value, **, default: "") if value.present?
           end
         end
       end

--- a/spec/components/ui/timeline/component_spec.rb
+++ b/spec/components/ui/timeline/component_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Timeline::Component do
+  it "renders a timeline with multiple steps" do
+    render_inline described_class.new do |timeline|
+      timeline.with_step("Step 1", status: :done)
+      timeline.with_step("Step 2", status: :current)
+      timeline.with_step("Step 3", status: :failed)
+      timeline.with_step("Step 4")
+    end
+
+    expect(page).to have_selector(".timeline") do |timeline|
+      expect(timeline).to have_selector(".timeline-step", count: 4)
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(1)") do |step|
+        expect(step).to have_html_attribute("class").to eq("timeline-step timeline-step--done")
+        expect(step).to have_text("Step 1")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(2)") do |step|
+        expect(step).to have_html_attribute("class").to eq("timeline-step timeline-step--current")
+        expect(step).to have_text("Step 2")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(3)") do |step|
+        expect(step).to have_html_attribute("class").to eq("timeline-step timeline-step--failed")
+        expect(step).to have_text("Step 3")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(4)") do |step|
+        expect(step).to have_html_attribute("class").to eq("timeline-step timeline-step--pending")
+        expect(step).to have_text("Step 4")
+      end
+    end
+  end
+
+  it "renders a timeline with dates" do
+    render_inline described_class.new do |timeline|
+      timeline.with_step("Step 1", status: :done,   date: Date.new(2024, 9, 16))
+      timeline.with_step("Step 2", status: :failed, date: Time.zone.local(2025, 2, 14, 9, 0))
+      timeline.with_step("Step 3")
+    end
+
+    expect(page).to have_selector(".timeline") do |timeline|
+      expect(timeline).to have_selector(".timeline-step:nth-child(1)") do |step|
+        expect(step).to have_selector(".timeline-step__date", text: "16/09/2024")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(2)") do |step|
+        expect(step).to have_selector(".timeline-step__date", text: "14/02/2025")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(3)") do |step|
+        expect(step).to have_no_selector(".timeline-step__date")
+      end
+    end
+  end
+
+  it "renders a timeline with string dates" do
+    render_inline described_class.new do |timeline|
+      timeline.with_step("Step 1", status: :done,   date: "01/01/2024")
+      timeline.with_step("Step 2", status: :failed, date: "03/2025")
+      timeline.with_step("Step 3")
+    end
+
+    expect(page).to have_selector(".timeline") do |timeline|
+      expect(timeline).to have_selector(".timeline-step:nth-child(1)") do |step|
+        expect(step).to have_selector(".timeline-step__date", text: "01/01/2024")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(2)") do |step|
+        expect(step).to have_selector(".timeline-step__date", text: "03/2025")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(3)") do |step|
+        expect(step).to have_no_selector(".timeline-step__date")
+      end
+    end
+  end
+
+  it "renders a timeline with icons" do
+    render_inline described_class.new do |timeline|
+      timeline.with_step("Step 1", status: :done,   icon: "check")
+      timeline.with_step("Step 2", status: :failed, icon: "envelope")
+      timeline.with_step("Step 3")
+    end
+
+    expect(page).to have_selector(".timeline") do |timeline|
+      expect(timeline).to have_selector(".timeline-step:nth-child(1)") do |step|
+        expect(step).to have_selector("svg") do |svg|
+          expect(svg).to have_html_attribute("data-source").to eq("heroicons/optimized/24/solid/check.svg")
+        end
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(2)") do |step|
+        expect(step).to have_selector("svg") do |svg|
+          expect(svg).to have_html_attribute("data-source").to eq("heroicons/optimized/24/solid/envelope.svg")
+        end
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(3)") do |step|
+        expect(step).to have_no_selector("svg")
+      end
+    end
+  end
+
+  it "renders a timeline with text in steps" do
+    render_inline described_class.new do |timeline|
+      timeline.with_step("Step 1", status: :done) do
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      end
+
+      timeline.with_step("Step 2", status: :failed) do
+        "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur."
+      end
+
+      timeline.with_step("Step 3")
+    end
+
+    expect(page).to have_selector(".timeline") do |timeline|
+      expect(timeline).to have_selector(".timeline-step:nth-child(1)") do |step|
+        expect(step).to have_selector(".timeline-step__title",       text: "Step 1")
+        expect(step).to have_selector(".timeline-step__description", text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit.")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(2)") do |step|
+        expect(step).to have_selector(".timeline-step__title",       text: "Step 2")
+        expect(step).to have_selector(".timeline-step__description", text: "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.")
+      end
+
+      expect(timeline).to have_selector(".timeline-step:nth-child(3)") do |step|
+        expect(step).to have_selector(".timeline-step__title", text: "Step 3")
+        expect(step).to have_no_selector(".timeline-step__description")
+      end
+    end
+  end
+end

--- a/spec/components/ui/timeline/preview_spec.rb
+++ b/spec/components/ui/timeline/preview_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe UI::Timeline::Preview do
+  it { is_expected.to render_preview_without_exception(:default) }
+  it { is_expected.to render_preview_without_exception(:with_icons) }
+end

--- a/spec/components/views/reports/show/timeline/component_spec.rb
+++ b/spec/components/views/reports/show/timeline/component_spec.rb
@@ -318,4 +318,92 @@ RSpec.describe Views::Reports::Show::Timeline::Component, type: :component do
       end
     end
   end
+
+  context "when current user is a ddfip user" do
+    before { sign_in_as(:ddfip) }
+
+    context "when report is assigned" do
+      let(:report) { create(:report, :assigned, :made_for_office) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Reception du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été assigné au guichet #{report.office.name}")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Résolution du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement est prêt à être traité")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Réponse à la collectivité")
+        expect(page).to have_selector(".timeline-step__description", text: "La collectivité n'a pas reçu de retour concernant ce signalement")
+      end
+    end
+
+    context "when report is applicable" do
+      let(:report) { create(:report, :applicable, :made_for_office) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Reception du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été assigné au guichet #{report.office.name}")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Traitement validé")
+        motif = I18n.t("enum.resolution_motif.#{report.form_type}.applicable.#{report.resolution_motif}")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été accepté par le guichet avec le motif « #{motif} »")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Réponse à la collectivité")
+        expect(page).to have_selector(".timeline-step__description", text: "La réponse du guichet sera transmise à la collectivité une fois confirmée par le référent fiabilisation")
+      end
+    end
+
+    context "when report is inapplicable" do
+      let(:report) { create(:report, :inapplicable, :made_for_office) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Reception du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été assigné au guichet #{report.office.name}")
+
+        expect(page).to have_selector(".timeline-step--failed .timeline-step__title", text: "Traitement annulé")
+        motif = I18n.t("enum.resolution_motif.#{report.form_type}.inapplicable.#{report.resolution_motif}")
+        expect(page).to have_selector(".timeline-step__description", text: "Le guichet a refusé le signalement pour le motif « #{motif} »")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Réponse à la collectivité")
+        expect(page).to have_selector(".timeline-step__description", text: "La réponse du guichet sera transmise à la collectivité une fois confirmée par le référent fiabilisation")
+      end
+    end
+
+    context "when report is approved" do
+      let(:report) { create(:report, :approved, :made_for_office) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Reception du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été assigné au guichet #{report.office.name}")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Traitement validé")
+        motif = I18n.t("enum.resolution_motif.#{report.form_type}.applicable.#{report.resolution_motif}")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été accepté par le guichet avec le motif « #{motif} »")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Réponse à la collectivité")
+        expect(page).to have_selector(".timeline-step__description", text: "La collectivité a reçu un retour positif")
+      end
+    end
+
+    context "when report is canceled" do
+      let(:report) { create(:report, :canceled, :made_for_office) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Reception du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été assigné au guichet #{report.office.name}")
+
+        expect(page).to have_selector(".timeline-step--failed .timeline-step__title", text: "Traitement annulé")
+        motif = I18n.t("enum.resolution_motif.#{report.form_type}.inapplicable.#{report.resolution_motif}")
+        expect(page).to have_selector(".timeline-step__description", text: "Le guichet a refusé le signalement pour le motif « #{motif} »")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Réponse à la collectivité")
+        expect(page).to have_selector(".timeline-step__description", text: "La collectivité a reçu un retour négatif")
+      end
+    end
+  end
 end

--- a/spec/components/views/reports/show/timeline/component_spec.rb
+++ b/spec/components/views/reports/show/timeline/component_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Views::Reports::Show::Timeline::Component, type: :component do
+  context "when current organization is a collectivity" do
+    before { sign_in_as(organization: report.collectivity) }
+
+    context "when report is draft" do
+      let(:report) { create(:report) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Complétion du formulaire")
+        expect(page).to have_selector(".timeline-step__description", text: "En attente de la complétion du formulaire")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Transmission du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement pourra être transmis à la DDFIP une fois le formulaire complété")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Acceptation du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP pourra accepter ou refuser de traiter le signalement lorsqu'il sera transmis")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP n'a pas encore répondu à propos de ce signalement")
+      end
+    end
+
+    context "when report is ready" do
+      let(:report) { create(:report, :ready) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Transmission du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement est prêt à être transmis à la DDFIP")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Acceptation du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP pourra accepter ou refuser de traiter le signalement lorsqu'il sera transmis")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP n'a pas encore répondu à propos de ce signalement")
+      end
+    end
+
+    context "when report is in active transmission" do
+      let(:report) { create(:report, :in_active_transmission) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Transmission du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "La transmission du signalement est en attente")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Acceptation du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP pourra accepter ou refuser de traiter le signalement lorsqu'il sera transmis")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP n'a pas encore répondu à propos de ce signalement")
+      end
+    end
+
+    context "when report is transmitted or acknowledged" do
+      let(:report) { create(:report, %i[transmitted acknowledged].sample) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement transmis")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été transmis à la DDFIP")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Acceptation du signalement")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a reçu le signalement et va le traiter prochainement")
+
+        expect(page).to have_selector(".timeline-step--pending .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP n'a pas encore répondu à propos de ce signalement")
+      end
+    end
+
+    context "when report is accepted, assigned, applicable or inapplicable" do
+      let(:report) { create(:report, %i[accepted assigned applicable inapplicable].sample) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement transmis")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été transmis à la DDFIP")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement accepté")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a reçu le signalement et accepté son traitement")
+
+        expect(page).to have_selector(".timeline-step--current .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP n'a pas encore répondu à propos de ce signalement")
+      end
+    end
+
+    context "when report is rejected" do
+      let(:report) { create(:report, :rejected) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement transmis")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été transmis à la DDFIP")
+
+        expect(page).to have_selector(".timeline-step--failed .timeline-step__title", text: "Signalement rejeté")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a rejeté le traitement du signalement")
+
+        expect(page).to have_selector(".timeline-step--failed .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a rejeté le traitement du signalement")
+      end
+    end
+
+    context "when report is approved" do
+      let(:report) { create(:report, :approved) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement transmis")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été transmis à la DDFIP")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement accepté")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a reçu le signalement et accepté son traitement")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a donné une réponse positive à ce signalement")
+      end
+    end
+
+    context "when report is canceled" do
+      let(:report) { create(:report, :canceled) }
+
+      it do
+        render_inline described_class.new(report)
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Formulaire complété")
+        expect(page).to have_selector(".timeline-step__description", text: "Le formulaire de signalement a été complété")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement transmis")
+        expect(page).to have_selector(".timeline-step__description", text: "Le signalement a été transmis à la DDFIP")
+
+        expect(page).to have_selector(".timeline-step--done .timeline-step__title", text: "Signalement accepté")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a reçu le signalement et accepté son traitement")
+
+        expect(page).to have_selector(".timeline-step--failed .timeline-step__title", text: "Réponse de la DDFIP")
+        expect(page).to have_selector(".timeline-step__description", text: "La DDFIP a donné une réponse négative à ce signalement")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ajoute une timeline sur la page des signalement :
<img width="985" height="145" alt="Capture d’écran 2025-08-19 à 15 29 38" src="https://github.com/user-attachments/assets/dea9009a-365f-4803-9e9a-710557eade54" />

La timeline change en fonction de l'utilisateur